### PR TITLE
Really small but important JSON fix

### DIFF
--- a/CompactSolarArrays/mcmod.info
+++ b/CompactSolarArrays/mcmod.info
@@ -17,7 +17,7 @@
   "parent":"",
   "requiredMods": [
     "IC2@[1.112,)",
-    "Forge@[6.6.1,)",
+    "Forge@[6.6.1,)"
   ],
   "dependencies": [
   	"IC2@[1.112,)"


### PR DESCRIPTION
Fixes `argo.saj.InvalidSyntaxException` while loading the mod.

Related post at http://forum.industrial-craft.net/index.php?page=Thread&postID=99334#post99334
