### PR TITLE
pt_BR version of Solar Arrays

### DIFF
--- a/CompactSolarArrays/resources/assets/compactsolars/lang/pt_BR
+++ b/CompactSolarArrays/resources/assets/compactsolars/lang/pt_BR
@@ -1,0 +1,7 @@
+tile.HV_block.name=Ordenador Solar de Alta Voltagem
+tile.MV_block.name=Ordenador Solar de Média Voltagem
+tile.LV_block.name=Ordenador Solar de Baixa Voltagem
+
+item.HVhat.name=Elmo Solar de Alta Voltagem
+item.MVhat.name=Elmo Solar de Média Voltagem
+item.LVhat.name=Elmo Solar de Baixa Voltagem


### PR DESCRIPTION
I've chose "Ordenador" in place of Arrays for it works as the literal translation (stands for "orderer") - As array is a programming word, its hard to find something that has an equivalent in portuguese.
